### PR TITLE
Articleモデルを修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,7 @@ class Article < ApplicationRecord
       article_params = Parallel.map(fetch_liked_tweets(user), in_threads: 5) do |tweet|
         if tweet.uris?
           article_url = tweet.uris.first.expanded_url.to_s
-          ({
+          {
             url: article_url,
             title: fetch_title(article_url),
             image_meta: fetch_og_image(article_url),
@@ -19,7 +19,7 @@ class Article < ApplicationRecord
             tweet_user_meta: tweet.user.profile_image_url_https.to_s,
             updated_at: DateTime.now,
             created_at: DateTime.now
-          })
+          }
         end
       end
       Article.insert_all(article_params.compact, unique_by: :url)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,11 +8,28 @@ class Article < ApplicationRecord
       article_params = Parallel.map(fetch_liked_tweets(user), in_threads: 5) do |tweet|
         if tweet.uris?
           article_url = tweet.uris.first.expanded_url.to_s
-          page = mechanize_agent.get(article_url)
+
+          begin
+            page = Scrape.access_page(article_url)
+            article_title = Scrape.fetch_title(page)
+            article_image = Scrape.fetch_og_image(page)
+          rescue Mechanize::ResponseCodeError => e
+            if e.response_code = 404
+              next
+            else
+              article_title = "Not Found"
+              article_image = "no_image.svg"
+            end
+          rescue => e
+            ErrorUtility.log e
+            article_title = "Not Found"
+            article_image = "no_image.svg"
+          end
+
           {
             url: article_url,
-            title: fetch_title(page),
-            image_meta: fetch_og_image(page),
+            title: article_title,
+            image_meta: article_image,
             user_id: user.id,
             tweet_id: tweet.id,
             tweeted_at: tweet.created_at,
@@ -39,27 +56,6 @@ class Article < ApplicationRecord
           config.access_token_secret = user.access_token_secret
         end
         client
-      end
-
-      def mechanize_agent
-        agent = Mechanize.new
-        agent.user_agent_alias = "Windows Chrome"
-        agent
-      end
-
-      def fetch_title(page)
-        page.title || "No Title"
-      rescue => e
-        ErrorUtility.log_and_notify e
-        "No Title"
-      end
-
-      def fetch_og_image(page)
-        og_image = page.at('meta[property="og:image"]')
-        og_image ? og_image[:content] : "no_image.svg"
-      rescue => e
-        ErrorUtility.log_and_notify e
-        "no_image.svg"
       end
 
       def fetch_liked_tweets(user)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -18,8 +18,8 @@ class Article < ApplicationRecord
             tweeted_at: tweet.created_at,
             tweet_url: tweet.url.to_s,
             tweet_user_meta: tweet.user.profile_image_url_https.to_s,
-            updated_at: DateTime.now,
-            created_at: DateTime.now
+            updated_at: Time.current,
+            created_at: Time.current
           }
         end
       end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,11 +8,12 @@ class Article < ApplicationRecord
       article_params = Parallel.map(fetch_liked_tweets(user), in_threads: 5) do |tweet|
         if tweet.uris?
           article_url = tweet.uris.first.expanded_url.to_s
+          crawler = Scrape.new(article_url)
 
           begin
-            page = Scrape.access_page(article_url)
-            article_title = Scrape.fetch_title(page)
-            article_image = Scrape.fetch_og_image(page)
+            page = crawler.access_page
+            article_title = crawler.fetch_title(page)
+            article_image = crawler.fetch_og_image(page)
           rescue Mechanize::ResponseCodeError => e
             if e.response_code = 404
               next

--- a/app/models/error_utility.rb
+++ b/app/models/error_utility.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ErrorUtility
-  def self.log_and_notify(e)
+  def self.log(e)
     Rails.logger.error e.class
     Rails.logger.error e.message
     Rails.logger.error e.backtrace.join("\n")

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -1,31 +1,33 @@
 # frozen_string_literal: true
 
 class Scrape
-  class << self
-    def access_page(url)
-      mechanize_agent.get(url)
-    end
+  def initialize(url)
+    @url = url
+  end
 
-    def fetch_title(page)
-      page.title || "No Title"
-    rescue => e
-      ErrorUtility.log e
-      "Not Found"
-    end
+  def access_page
+    mechanize_agent.get(@url)
+  end
 
-    def fetch_og_image(page)
-      og_image = page.at('meta[property="og:image"]')
-      og_image ? og_image[:content] : "no_image.svg"
-    rescue => e
-      ErrorUtility.log e
-      "no_image.svg"
-    end
+  def fetch_title(page)
+    page.title || "No Title"
+  rescue => e
+    ErrorUtility.log e
+    "Not Found"
+  end
 
-    private
-      def mechanize_agent
-        agent = Mechanize.new
-        agent.user_agent_alias = "Windows Chrome"
-        agent
-      end
+  def fetch_og_image(page)
+    og_image = page.at('meta[property="og:image"]')
+    og_image ? og_image[:content] : "no_image.svg"
+  rescue => e
+    ErrorUtility.log e
+    "no_image.svg"
+  end
+
+  private
+    def mechanize_agent
+      agent = Mechanize.new
+      agent.user_agent_alias = "Windows Chrome"
+      agent
     end
 end

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Scrape
+  class << self
+    def access_page(url)
+      mechanize_agent.get(url)
+    end
+
+    def fetch_title(page)
+      page.title || "No Title"
+    rescue => e
+      ErrorUtility.log e
+      "Not Found"
+    end
+
+    def fetch_og_image(page)
+      og_image = page.at('meta[property="og:image"]')
+      og_image ? og_image[:content] : "no_image.svg"
+    rescue => e
+      ErrorUtility.log e
+      "no_image.svg"
+    end
+
+    private
+      def mechanize_agent
+        agent = Mechanize.new
+        agent.user_agent_alias = "Windows Chrome"
+        agent
+      end
+    end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module Twilinks
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = "Tokyo"
     config.i18n.default_locale = :ja
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/spec/models/scrape_spec.rb
+++ b/spec/models/scrape_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scrape, type: :model do
+  describe "::fetch_title" do
+    it "URLからタイトルを取得できること" do
+      page = Scrape.access_page("http://example.com/")
+      expect(Scrape.fetch_title(page)).to eq "Example Domain"
+    end
+  end
+
+  describe "::fetch_og_image" do
+    context "任意のページにog:imageタグが存在するとき" do
+      it "og:imageタグの要素を取得できること" do
+        page = Scrape.access_page("https://shibaaa647.hatenablog.com/")
+        expect(Scrape.fetch_og_image(page)).to eq "https://cdn.blog.st-hatena.com/images/theme/og-image-1500.png"
+      end
+    end
+
+    context "任意のページog:imageタグが存在しないとき" do
+      it "'no_image.svg'が返ること" do
+        page = Scrape.access_page("http://example.com/")
+        expect(Scrape.fetch_og_image(page)).to eq "no_image.svg"
+      end
+    end
+  end
+end

--- a/spec/models/scrape_spec.rb
+++ b/spec/models/scrape_spec.rb
@@ -3,25 +3,28 @@
 require "rails_helper"
 
 RSpec.describe Scrape, type: :model do
-  describe "::fetch_title" do
+  describe "#fetch_title" do
     it "URLからタイトルを取得できること" do
-      page = Scrape.access_page("http://example.com/")
-      expect(Scrape.fetch_title(page)).to eq "Example Domain"
+      crawler = Scrape.new("http://example.com/")
+      page = crawler.access_page
+      expect(crawler.fetch_title(page)).to eq "Example Domain"
     end
   end
 
-  describe "::fetch_og_image" do
+  describe "#fetch_og_image" do
     context "任意のページにog:imageタグが存在するとき" do
       it "og:imageタグの要素を取得できること" do
-        page = Scrape.access_page("https://shibaaa647.hatenablog.com/")
-        expect(Scrape.fetch_og_image(page)).to eq "https://cdn.blog.st-hatena.com/images/theme/og-image-1500.png"
+        crawler = Scrape.new("https://shibaaa647.hatenablog.com/")
+        page = crawler.access_page
+        expect(crawler.fetch_og_image(page)).to eq "https://cdn.blog.st-hatena.com/images/theme/og-image-1500.png"
       end
     end
 
-    context "任意のページog:imageタグが存在しないとき" do
+    context "任意のページにog:imageタグが存在しないとき" do
       it "'no_image.svg'が返ること" do
-        page = Scrape.access_page("http://example.com/")
-        expect(Scrape.fetch_og_image(page)).to eq "no_image.svg"
+        crawler = Scrape.new("http://example.com/")
+        page = crawler.access_page
+        expect(crawler.fetch_og_image(page)).to eq "no_image.svg"
       end
     end
   end


### PR DESCRIPTION
- Mechanizeのgetを、URLごとに一回で済むように修正。
- Articleモデルの`created_at`カラムの値に`Time.current`を使用するよう変更。
- スクレイピングする処理を`Scrape`クラスに切り出した。
- ref #65 スクレイピングの際に404が返ってきたらスキップするように変更。