### PR TITLE
ArticleモデルとScrapeクラスをリファクタリング

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,42 +5,42 @@ class Article < ApplicationRecord
 
   class << self
     def insert_from_tweets(user)
+      crawler = Scrape.mechanize_agent
       article_params = Parallel.map(fetch_liked_tweets(user), in_threads: 5) do |tweet|
-        if tweet.uris?
-          article_url = tweet.uris.first.expanded_url.to_s
-          crawler = Scrape.new(article_url)
+        next if tweet.uris.blank?
+        article_url = tweet.uris.first.expanded_url.to_s
 
-          begin
-            page = crawler.access_page
-            article_title = crawler.fetch_title(page)
-            article_image = crawler.fetch_og_image(page)
-          rescue Mechanize::ResponseCodeError => e
-            if e.response_code == "404"
-              next
-            else
-              article_title = "Not Found"
-              article_image = "no_image.svg"
-            end
-          rescue => e
-            ErrorUtility.log e
+        begin
+          page = Scrape.access_page(crawler, article_url)
+          article_title = Scrape.fetch_title(page)
+          article_image = Scrape.fetch_og_image(page)
+        rescue Mechanize::ResponseCodeError => e
+          if e.response_code == "404"
+            next
+          else
             article_title = "Not Found"
             article_image = "no_image.svg"
           end
-
-          {
-            url: article_url,
-            title: article_title,
-            image_meta: article_image,
-            user_id: user.id,
-            tweet_id: tweet.id,
-            tweeted_at: tweet.created_at,
-            tweet_url: tweet.url.to_s,
-            tweet_user_meta: tweet.user.profile_image_url_https.to_s,
-            updated_at: Time.current,
-            created_at: Time.current
-          }
+        rescue => e
+          ErrorUtility.log e
+          article_title = "Not Found"
+          article_image = "no_image.svg"
         end
+
+        {
+          url:             article_url,
+          title:           article_title,
+          image_meta:      article_image,
+          user_id:         user.id,
+          tweet_id:        tweet.id,
+          tweeted_at:      tweet.created_at,
+          tweet_url:       tweet.url.to_s,
+          tweet_user_meta: tweet.user.profile_image_url_https.to_s,
+          updated_at:      Time.current,
+          created_at:      Time.current
+        }
       end
+
       Article.insert_all(article_params.compact, unique_by: :url)
     end
 

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -1,33 +1,30 @@
 # frozen_string_literal: true
 
 class Scrape
-  def initialize(url)
-    @url = url
-  end
-
-  def access_page
-    mechanize_agent.get(@url)
-  end
-
-  def fetch_title(page)
-    page.title || "No Title"
-  rescue => e
-    ErrorUtility.log e
-    "Not Found"
-  end
-
-  def fetch_og_image(page)
-    og_image = page.at('meta[property="og:image"]')
-    og_image ? og_image[:content] : "no_image.svg"
-  rescue => e
-    ErrorUtility.log e
-    "no_image.svg"
-  end
-
-  private
+  class << self
     def mechanize_agent
       agent = Mechanize.new
       agent.user_agent_alias = "Windows Chrome"
       agent
     end
+
+    def access_page(agent, url)
+      agent.get(url)
+    end
+
+    def fetch_title(page)
+      page.title || "No Title"
+    rescue => e
+      ErrorUtility.log e
+      "Not Found"
+    end
+
+    def fetch_og_image(page)
+      og_image = page.at('meta[property="og:image"]')
+      og_image ? og_image[:content] : "no_image.svg"
+    rescue => e
+      ErrorUtility.log e
+      "no_image.svg"
+    end
+  end
 end

--- a/spec/models/scrape_spec.rb
+++ b/spec/models/scrape_spec.rb
@@ -5,26 +5,26 @@ require "rails_helper"
 RSpec.describe Scrape, type: :model do
   describe "#fetch_title" do
     it "URLからタイトルを取得できること" do
-      crawler = Scrape.new("http://example.com/")
-      page = crawler.access_page
-      expect(crawler.fetch_title(page)).to eq "Example Domain"
+      crawler = Scrape.mechanize_agent
+      page = Scrape.access_page(crawler, "http://example.com/")
+      expect(Scrape.fetch_title(page)).to eq "Example Domain"
     end
   end
 
   describe "#fetch_og_image" do
     context "任意のページにog:imageタグが存在するとき" do
       it "og:imageタグの要素を取得できること" do
-        crawler = Scrape.new("https://shibaaa647.hatenablog.com/")
-        page = crawler.access_page
-        expect(crawler.fetch_og_image(page)).to eq "https://cdn.blog.st-hatena.com/images/theme/og-image-1500.png"
+        crawler = Scrape.mechanize_agent
+        page = Scrape.access_page(crawler, "https://shibaaa647.hatenablog.com/")
+        expect(Scrape.fetch_og_image(page)).to eq "https://cdn.blog.st-hatena.com/images/theme/og-image-1500.png"
       end
     end
 
     context "任意のページにog:imageタグが存在しないとき" do
       it "'no_image.svg'が返ること" do
-        crawler = Scrape.new("http://example.com/")
-        page = crawler.access_page
-        expect(crawler.fetch_og_image(page)).to eq "no_image.svg"
+        crawler = Scrape.mechanize_agent
+        page = Scrape.access_page(crawler, "http://example.com/")
+        expect(Scrape.fetch_og_image(page)).to eq "no_image.svg"
       end
     end
   end


### PR DESCRIPTION
ref #72 
Twitter APIからのレスポンスをループで処理する際、ループ内で毎回インスタンス化していてパフォーマンスが悪いため、クラスメソッド化して改善。

APIを叩いてインサートが終わるまでの時間をローカルで計測し、速くなることを確認。
- 改善前
12000ms 
- 改善後
8065ms