### PR TITLE
スクレイピングをするクラスを修正

### DIFF
--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class Scrape
+  TIMEOUT_SEC = 3
   class << self
     def mechanize_agent
       agent = Mechanize.new
       agent.user_agent_alias = "Windows Chrome"
+      agent.open_timeout = TIMEOUT_SEC
+      agent.read_timeout = TIMEOUT_SEC
       agent
     end
 

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -17,17 +17,11 @@ class Scrape
 
     def fetch_title(page)
       page.title || "No Title"
-    rescue => e
-      ErrorUtility.log e
-      "Not Found"
     end
 
     def fetch_og_image(page)
       og_image = page.at('meta[property="og:image"]')
       og_image ? og_image[:content] : "no_image.svg"
-    rescue => e
-      ErrorUtility.log e
-      "no_image.svg"
     end
   end
 end


### PR DESCRIPTION
- connect timeoutとread timeoutを設定
  - スクレイピングのタイムアウトを設けて後続処理を優先させる
  - 本番環境でスクレイピングを含む処理がタイムアウトしてアプリケーションエラーになっていたため
- 呼び出し元と重複する例外処理を削除