### PR TITLE
余分な空白を削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   class << self
     def find_for_twitter_oauth(auth)
-      auth_user = User.find_or_create_by(uid: auth.uid, provider: auth. provider) do |user|
+      auth_user = User.find_or_create_by(uid: auth.uid, provider: auth.provider) do |user|
         user.name                = auth.info.nickname
         user.email               = dummy_email(auth)
         user.password            = Devise.friendly_token[0, 20]


### PR DESCRIPTION
メソッド内で余分な空白が入っており、意図した挙動になっていないので空白を削除した。