### PR TITLE
tzinfo-dataを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,5 +59,3 @@ group :development do
   gem "rubocop-rails", require: false
   gem "bullet"
 end
-
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,7 +433,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen
   twitter
-  tzinfo-data
   vcr
   web-console
   webdrivers


### PR DESCRIPTION
## Description

`bundle install`するたびに出ていたwarningを解消するため、`tzinfo-data`gemを削除。
```sh
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
```

### 参考

- https://qiita.com/tatama/items/3f0f5e42cb5f75b53817
- https://k-koh.hatenablog.com/entry/2020/02/02/172126
- https://github.com/tzinfo/tzinfo-data/issues/12#issuecomment-279554001

## Issue

- #issue_no
