### PR TITLE
dead_end gemを追加

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--require dead_end

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem "vcr"
   gem "pry-byebug"
   gem "pry-rails"
+  gem "dead_end"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dead_end (1.1.7)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -401,6 +402,7 @@ DEPENDENCIES
   bulma-rails
   byebug
   capybara
+  dead_end
   devise
   devise-i18n
   dotenv-rails


### PR DESCRIPTION
## Description

コード内で`end`が抜けていたらエラーでどう直すべきかわかるようになった

### 定義元

```rb
# twi_links/app/controllers/articles_controller.rb
def hoge
  puts "dead_end"
```

### エラー

```sh
Run `$ dead_end /Users/shibatakoutasuku/ghq/github.com/shibaaaa/twi_links/app/controllers/articles_controller.rb` for more options

DeadEnd: Missing `end` detected

This code has a missing `end`. Ensure that all
syntax keywords (`def`, `do`, etc.) have a matching `end`.

file: /Users/shibatakoutasuku/ghq/github.com/shibaaaa/twi_links/app/controllers/articles_controller.rb
simplified:

    ❯  3  class ArticlesController < ApplicationController
    ❯ 32    def hoge
    ❯ 34  end




SyntaxError (/Users/shibatakoutasuku/ghq/github.com/shibaaaa/twi_links/app/controllers/articles_controller.rb:34: syntax error, unexpected end-of-input, expecting `end'):

app/controllers/articles_controller.rb:34: syntax error, unexpected end-of-input, expecting `end'
app/controllers/articles_controller.rb:34: syntax error, unexpected end-of-input, expecting `end'
app/controllers/articles_controller.rb:34: syntax error, unexpected end-of-input, expecting `end'
```

## Issue

- #100 
