### PR TITLE
circleciの設定を修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+
+orbs:
+  ruby: circleci/ruby@1.1.2
+  browser-tools: circleci/browser-tools@1.1.3
 jobs:
   build:
     parallelism: 3
@@ -59,6 +63,9 @@ jobs:
       - run:
           name: Database setup
           command: bundle exec rake db:schema:load
+
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
 
       - run:
           name: Rails test


### PR DESCRIPTION
## Description

親ブランチで下記エラーでテストが落ちていたため対応。
CircleCIのみ落ちている。
```
Webdrivers::BrowserNotFound:
Failed to find Chrome binary.
```

### 参考

- [CircleCIのベースイメージを次世代イメージ cimg に移行する \- Hack Your Design\!](https://blog.toshimaru.net/use-circleci-cimg/)
- [CircleCI config\.yml ひな型 Rails 6 / PostgreSQL / Rspec（orbと最新のimageの利用） \- Qiita](https://qiita.com/kazutosato/items/3f08a4da350a395f3bd2)
- [CircleCIのorbsを使って設定ファイルを整理するMEMO \- Madogiwa Blog](https://madogiwa0124.hatenablog.com/entry/2020/09/27/233519)