### PR TITLE
pry-byebugのバージョンアップ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :development, :test do
   gem "webmock"
   gem "vcr"
   gem "pry-byebug"
-  gem "pry-rails"
   gem "dead_end"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem "webdrivers"
   gem "webmock"
   gem "vcr"
-  gem "pry-byebug"
+  gem "pry-byebug", ">= 3.9.0"
   gem "dead_end"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,12 +209,12 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
-    pry (0.14.1)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -417,7 +417,7 @@ DEPENDENCIES
   omniauth-twitter
   parallel
   pg
-  pry-byebug
+  pry-byebug (>= 3.9.0)
   puma (~> 4.1)
   rails (= 6.0.4)
   rails-i18n

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,8 +215,6 @@ GEM
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -420,7 +418,6 @@ DEPENDENCIES
   parallel
   pg
   pry-byebug
-  pry-rails
   puma (~> 4.1)
   rails (= 6.0.4)
   rails-i18n


### PR DESCRIPTION
## Description

Railsサーバー起動時に出ていたwarningを消すため、pry-byebugのバージョンを上げた。
その際pry-railsとpryの依存関係がコンフリクトした&&pry-byebugのみでデバッグは出来るため、pry-railsはuninstallした。

コンフリクトした際のログ。
```sh
Bundler could not find compatible versions for gem "pry":
  In snapshot (Gemfile.lock):
    pry (>= 0.14.1)

  In Gemfile:
    pry-byebug (= 3.9.0) was resolved to 3.9.0, which depends on
      pry (~> 0.13.0)

    pry-rails was resolved to 0.3.9, which depends on
      pry (>= 0.10.4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

## Issue

- #110 