### PR TITLE
Rails6.1で不要になったgemの削除とspringのアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development do
   gem "web-console"
   gem "listen"
   gem "spring"
-  gem "spring-watcher-listen"
 
   # Not default
   gem "slim_lint"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     slim_lint (0.22.1)
       rubocop (>= 0.78.0)
       slim (>= 3.0, < 5.0)
-    spring (2.1.1)
+    spring (4.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,9 +337,6 @@ GEM
       rubocop (>= 0.78.0)
       slim (>= 3.0, < 5.0)
     spring (2.1.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -438,7 +435,6 @@ DEPENDENCIES
   slim-rails
   slim_lint
   spring
-  spring-watcher-listen
   twitter
   vcr
   web-console


### PR DESCRIPTION
## Description

Rails6.1.1.4にバージョンアップした際、Rails6.1ではデフォルトでインストールされない`spring-watcher-listen` を削除した。
`spring-watcher-listen` が削除されたことでspringのバージョンアップができるようになったためその対応も実施。

### railsdiff

https://railsdiff.org/6.0.4/6.1.4.4