### PR TITLE
ツイートに含まれるURLへのアクセスでタイムアウトすると500エラーになってしまうので、例外処理を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -14,6 +14,8 @@ class Article < ApplicationRecord
           page = crawler.access_page(article_url)
           article_title = crawler.fetch_title(page)
           article_image = crawler.fetch_og_image(page)
+        rescue Timeout::Error
+          next
         rescue => e
           next if e.response_code == "404"
           ErrorUtility.log e


### PR DESCRIPTION
## Description

ローカルで動作確認時にタイムアウトエラーで500エラーとなり落ちてしまうことがあったので例外処理を追加した。

### stack trace

```sh
NoMethodError (undefined method `response_code' for #<Net::ReadTimeout: Net::ReadTimeout>

          next if e.response_code == "404"
                   ^^^^^^^^^^^^^^
Did you mean?  respond_to?):

app/models/article.rb:18:in `rescue in block in insert_from_tweets'
app/models/article.rb:13:in `block in insert_from_tweets'
```