### PR TITLE
開発環境とテスト環境でdeprecationなコードを検知したらエラーを吐いて気づけるようにした

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,10 +42,10 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise exceptions for disallowed deprecations.
-  config.active_support.disallowed_deprecation = :raise
+  config.active_support.disallowed_deprecation = :stderr
 
   # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
+  config.active_support.disallowed_deprecation_warnings = :all
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,10 +44,10 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raise exceptions for disallowed deprecations.
-  config.active_support.disallowed_deprecation = :raise
+  config.active_support.disallowed_deprecation = :stderr
 
   # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
+  config.active_support.disallowed_deprecation_warnings = :all
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
## Description

Railsのバージョンアップでdeprecation warningを潰す必要があるが、対象のコードに気づけるように開発環境とテスト環境では非推奨のコードがあればエラーを吐いてて気づけるようにした。