### PR TITLE
記事の登録時に例外処理がうまく動かない問題を解消

### DIFF
--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -11,5 +11,29 @@ RSpec.describe Article, type: :model do
       Article.insert_from_tweets(liked_tweets, user_1.id)
       expect(user_1.articles.exists?(url: "https://shibaaa647.hatenablog.com/entry/2020/10/05/101550")).to be true
     end
+
+    context "ツイートにあるURLへのスクレイピングでタイムアウトが発生した場合" do
+      let!(:timeout_errors) { [Timeout::Error, Net::ReadTimeout] }
+
+      before do
+        scrape_mock = double("Scrape")
+        allow(scrape_mock).to receive(:access_page).and_raise(timeout_errors.sample)
+
+        allow(Scrape).to receive(:new).and_return(scrape_mock)
+      end
+
+      it "処理が続行され、レコードに追加されないこと" do
+        liked_tweets = TwitterApi.new(user_1.access_token, user_1.access_token_secret).fetch_liked_tweets
+        Article.insert_from_tweets(liked_tweets, user_1.id)
+        expect(user_1.articles.exists?(url: "https://shibaaa647.hatenablog.com/entry/2020/10/05/101550")).to be false
+      end
+    end
+
+    context "取得したツイート全てにURLがない場合" do
+      it "nilを返すこと" do
+        result = Article.insert_from_tweets([], user_1.id)
+        expect(result).to eq nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

スクレイピング時にNet::ReadTimeoutが起きることがあるがキャッチできておらず、
後続処理でメソッド呼び出しに失敗していた。
Net::ReadTimeoutもキャッチするように処理を追加し、テストを追加。
その際にツイートにURLがない場合にも落ちることが発見され、追加で対応

## Issue

- #211
