### PR TITLE
ツイートにURLがなかった場合のフラッシュメッセージを分岐した

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -14,8 +14,10 @@ class ArticlesController < ApplicationController
 
   def create
     liked_tweets = TwitterApi.new(current_user.access_token, current_user.access_token_secret).fetch_liked_tweets
-    Article.insert_from_tweets(liked_tweets, current_user.id)
-    redirect_to root_path, notice: "いいねしたツイートから記事を取得しました。"
+    result = Article.insert_from_tweets(liked_tweets, current_user.id)
+    message =
+      result.nil? ? "いいねしたツイートの中に記事のURLがありませんでした。" : "いいねしたツイートから記事を取得しました。"
+    redirect_to root_path, notice: message
   rescue Twitter::Error::TooManyRequests => e
     redirect_to root_path, alert: "いいねの数が多すぎるため、読み込めませんでした。"
     ErrorUtility.log_and_notify e

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  describe "POST /articles", vcr: "twitter_api_get_response" do
+    let!(:user) { create(:user) }
+    before { login_as user }
+
+    context "いいねしたツイートにURLがある場合" do
+      it "flashメッセージが正しいこと" do
+        post articles_path
+
+        expect(response).to redirect_to root_path
+        expect(flash[:notice]).to eq("いいねしたツイートから記事を取得しました。")
+      end
+    end
+
+    context "いいねしたツイートにURLがない場合" do
+      before do
+        allow(Article).to receive(:insert_from_tweets).and_return(nil)
+      end
+
+      it "flashメッセージが正しいこと" do
+        post articles_path
+        expect(response).to redirect_to root_path
+        expect(flash[:notice]).to eq("いいねしたツイートの中に記事のURLがありませんでした。")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

#212 で表題の件を考慮した実装を追加したため、ユーザーに表示するメッセージを分岐させることでその意図がわかるようにする