### PR TITLE
articlesテーブルのカラム全てにNOT NULL制約を付与

### DIFF
--- a/db/migrate/20220812050843_add_not_null_constraint_to_articles.rb
+++ b/db/migrate/20220812050843_add_not_null_constraint_to_articles.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintToArticles < ActiveRecord::Migration[7.0]
+  def change
+    change_column :articles, :tweeted_at, :date, null: false
+    change_column :articles, :tweet_id, :string, null: false
+    change_column :articles, :title, :string, null: false
+    change_column :articles, :image_meta, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
-
-ActiveRecord::Schema[6.1].define(version: 2021_09_12_045153) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_12_050843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,12 +9,12 @@ ActiveRecord::Schema[6.1].define(version: 2021_09_12_045153) do
     t.string "url", null: false
     t.string "tweet_url", null: false
     t.string "tweet_user_meta", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.date "tweeted_at"
-    t.string "tweet_id"
-    t.string "title"
-    t.text "image_meta"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "tweeted_at", null: false
+    t.string "tweet_id", null: false
+    t.string "title", null: false
+    t.text "image_meta", null: false
     t.index ["tweeted_at"], name: "index_articles_on_tweeted_at"
     t.index ["url"], name: "index_articles_on_url", unique: true
     t.index ["user_id"], name: "index_articles_on_user_id"
@@ -36,10 +24,10 @@ ActiveRecord::Schema[6.1].define(version: 2021_09_12_045153) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "provider", null: false
     t.string "uid", null: false
     t.string "name", null: false


### PR DESCRIPTION


## Description


nullになりうるカラムが存在しないので、nullを弾いてクエリのしやすさやschemaの変更に強くする
