### PR TITLE
articlesテーブルにuser_idとtweeted_atの複合indexを張り直した

### DIFF
--- a/db/migrate/20220812052304_change_columns_index_to_articles.rb
+++ b/db/migrate/20220812052304_change_columns_index_to_articles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ChangeColumnsIndexToArticles < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :articles, :user_id
+    remove_index :articles, :tweeted_at
+    add_index :articles, [:user_id, :tweeted_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_12_050843) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_12_052304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -15,9 +15,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_050843) do
     t.string "tweet_id", null: false
     t.string "title", null: false
     t.text "image_meta", null: false
-    t.index ["tweeted_at"], name: "index_articles_on_tweeted_at"
     t.index ["url"], name: "index_articles_on_url", unique: true
-    t.index ["user_id"], name: "index_articles_on_user_id"
+    t.index ["user_id", "tweeted_at"], name: "index_articles_on_user_id_and_tweeted_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION


## Description
記事一覧画面でuser_idで絞り込んだ後にtweeted_atでソートするため、より有効なindexを使うようにする
