### PR TITLE
jbuilderをアンインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "rails", "7.0.3.1"
 gem "puma", "~> 5.6"
 gem "sass-rails"
 gem "webpacker"
-gem "jbuilder"
 gem "bootsnap", require: false
 
 # Not default

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,9 +147,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     json (2.6.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -439,7 +436,6 @@ DEPENDENCIES
   factory_bot_rails
   font-awesome-sass
   html2slim
-  jbuilder
   kaminari
   listen
   mechanize


### PR DESCRIPTION


## Description

使用していないため。
不要なgemを削除することでメンテナンスコストを下げるため。